### PR TITLE
Cleanup & Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Read the [Documentation](https://docs.monk.io/docs/).
 
 ## Basic Usage
 
-First, load all templates in this order:
+Update your runnable variable with name of appropriate version of polkadot node(node or node-persistent) in basic-monitoring.yaml e.g. `runnable: substrate/polkadot-node-persistent`.
+
+Load all templates in this order:
 
 ```
 monk load polkadot.yaml acala.yaml monitoring-files.yaml basic-monitoring.yaml

--- a/acala.yaml
+++ b/acala.yaml
@@ -17,7 +17,7 @@ acala-node:
       bash: <- `/usr/local/bin/acala --name="${name}" --ws-external --rpc-external ${options}`
   variables:
     defines: variables
-    options: ""
+    options: "-linfo --chain dev"
     name: acala-node-on-monk-io
 
 karura-node:
@@ -95,7 +95,7 @@ acala-node-v2.3.1:
   version: 2.3.1
   containers:
     node:
-      image-tag: v2.3.1
+      image-tag: 2.3.1
 
 acala-node-latest:
   defines: runnable
@@ -103,7 +103,7 @@ acala-node-latest:
   version: 2.3.1
   containers:
     node:
-      image-tag: v2.3.1
+      image-tag: 2.3.1
 
 karura-node-latest:
   defines: runnable
@@ -111,7 +111,7 @@ karura-node-latest:
   version: 2.3.1
   containers:
     node:
-      image-tag: v2.3.1
+      image-tag: 2.3.1
 
 karura-node-v2.3.1:
   defines: runnable
@@ -119,7 +119,7 @@ karura-node-v2.3.1:
   version: 2.3.1
   containers:
     node:
-      image-tag: v2.3.1
+      image-tag: 2.3.1
 
 karura-collator-latest:
   defines: runnable
@@ -127,7 +127,7 @@ karura-collator-latest:
   version: 2.3.1
   containers:
     node:
-      image-tag: v2.3.1
+      image-tag: 2.3.1
 
 karura-collator-v2.3.1:
   defines: runnable
@@ -135,7 +135,7 @@ karura-collator-v2.3.1:
   version: 2.3.1
   containers:
     node:
-      image-tag: v2.3.1
+      image-tag: 2.3.1
 
 acala-collator-latest:
   defines: runnable
@@ -143,7 +143,7 @@ acala-collator-latest:
   version: 2.3.1
   containers:
     node:
-      image-tag: v2.3.1
+      image-tag: 2.3.1
 
 acala-collator-v2.3.1:
   defines: runnable
@@ -151,4 +151,4 @@ acala-collator-v2.3.1:
   version: 2.3.1
   containers:
     node:
-      image-tag: v2.3.1
+      image-tag: 2.3.1

--- a/basic-monitoring.yaml
+++ b/basic-monitoring.yaml
@@ -27,7 +27,7 @@ prometheus:
               - targets: ["{{ v "polkadot-node-addr" }}:9615"]
   variables:
     defines: variables
-    runnable: polkadot/node
+    runnable: substrate/polkadot-node-persistent
     polkadot-node-addr:
       type: string
       value: <- get-hostname($runnable, "node")
@@ -44,7 +44,7 @@ grafana:
     defines: variables
     prometheus-addr:
       type: string
-      value: <- get-hostname("polkadot/prometheus", "prometheus")
+      value: <- get-hostname("substrate/prometheus", "prometheus")
   files:
     defines: files
     provisioning-dashboards:

--- a/polkadot.yaml
+++ b/polkadot.yaml
@@ -29,16 +29,22 @@ polkadot-node-persistent:
   volumes:
     defines: volumes
     polkadot-db:
-      size: 150
+      size: 200
       kind: SSD
       path: <- `${monk-volume-path}/polkadot_${name}`
 
-polkadot-validator-node:
+polkadot-node-validator:
   defines: runnable
-  inherits: substrate/polkadot-node-persistent
+  inherits: substrate/polkadot-node
+  volumes:
+    defines: volumes
+    polkadot-validator:
+      size: 150
+      kind: SSD
+      path: <- `${monk-volume-path}/polkadot_${name}`
   variables:
     options: --validator --ws-port 9944 --unsafe-ws-external --unsafe-pruning --pruning 1000 --rpc-methods=Unsafe -l'sync=warn,afg=warn,babe=warn' --telemetry-url 'wss://telemetry.polkadot.io/submit/ 1'
-    name: hd-validator-node-on-monk-io
+    name: polkadot-hd-validator-node-on-monk-io
 
 westend:
   inherits: substrate/polkadot-node
@@ -47,67 +53,34 @@ westend:
     options: --ws-external --rpc-external --chain=westend
     name: westend-node-on-monk-io
 
-
-polkadot-node-v0.9.16:
+polkadot-node-v0.9.17:
   defines: runnable
   inherits: ./polkadot-node
-  version: 0.9.16
+  version: 0.9.17
   containers:
     node:
-      image-tag: v0.9.16
+      image-tag: v0.9.17
 
-polkadot-node-latest:
-  defines: runnable
-  inherits: ./polkadot-node
-  version: 0.9.16
-  containers:
-    node:
-      image-tag: v0.9.16
-
-polkadot-node-persistent-latest:
+polkadot-node-persistent-v0.9.17:
   defines: runnable
   inherits: ./polkadot-node-persistent
-  version: 0.9.16
+  version: 0.9.17
   containers:
     node:
-      image-tag: v0.9.16
+      image-tag: v0.9.17
 
-polkadot-node-persistent-v0.9.16:
-  defines: runnable
-  inherits: ./polkadot-node-persistent
-  version: 0.9.16
-  containers:
-    node:
-      image-tag: v0.9.16
-
-polkadot-validator-node-latest:
+polkadot-validator-node-v0.9.17:
   defines: runnable
   inherits: ./polkadot-validator-node
-  version: 0.9.16
+  version: 0.9.17
   containers:
     node:
-      image-tag: v0.9.16
+      image-tag: v0.9.17
 
-polkadot-validator-node-v0.9.16:
-  defines: runnable
-  inherits: ./polkadot-validator-node
-  version: 0.9.16
-  containers:
-    node:
-      image-tag: v0.9.16
-
-westend-latest:
+westend-v0.9.17:
   defines: runnable
   inherits: ./westend
-  version: 0.9.16
+  version: 0.9.17
   containers:
     node:
-      image-tag: v0.9.16
-
-westend-v0.9.16:
-  defines: runnable
-  inherits: ./westend
-  version: 0.9.16
-  containers:
-    node:
-      image-tag: v0.9.16
+      image-tag: v0.9.17


### PR DESCRIPTION
* Updated slightly README.md to reflect needed changes to the file when loading basic-monitoring.yaml  
* Fixed image-tag in acala.yaml
* Fixed runnable in basic-monitoring.yaml
* Cleaned up polkadot.yaml. Bumped image-tag, remove `latest` workloads since they were already latest as they were inheriting from polkadot base. Updated volume name in pokladot validtor as it is conflicting with base polkadot node.